### PR TITLE
Localize Dataporten URL

### DIFF
--- a/connect/utils.py
+++ b/connect/utils.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from uninett_api.settings._secrets import DATAPORTEN_HEADERS, SOCIAL_AUTH_DATAPORTEN_SECRET, SOCIAL_AUTH_DATAPORTEN_KEY
+from uninett_api.settings._secrets import DATAPORTEN_HEADERS, DATAPORTEN_SECRET, DATAPORTEN_KEY
 from uninett_api.settings._test import BACKEND_URL
 
 
@@ -10,8 +10,8 @@ def get_access_token(code):
     url = 'https://auth.dataporten.no/oauth/token'
     payload = {'grant_type': 'authorization_code',
                'code': code,
-               'client_id': SOCIAL_AUTH_DATAPORTEN_KEY,
-               'client_secret': SOCIAL_AUTH_DATAPORTEN_SECRET,
+               'client_id': DATAPORTEN_KEY,
+               'client_secret': DATAPORTEN_SECRET,
                'redirect_uri': f"{BACKEND_URL}/connect/complete/dataporten/"}
 
     response = requests.post(url=url, data=payload, headers=DATAPORTEN_HEADERS)

--- a/connect/views.py
+++ b/connect/views.py
@@ -5,6 +5,7 @@ from connect.classes.adapter import HiveManagerAdapter
 from connect.classes.authenticator import FeideAuthenticator
 from connect.utils import get_access_token, get_user_data, get_first_name
 from iotconnect.classes import IotConnectView
+from uninett_api.settings._secrets import DATAPORTEN_URL
 from uninett_api.settings._test import FRONTEND_URL
 
 
@@ -26,8 +27,7 @@ class ConnectView(IotConnectView):
             user_data = session.get('user_data', [])
             url = f"{FRONTEND_URL}?session_key={session._session_key}&name={get_first_name(user_data)}"
         else:
-            url = "https://auth.dataporten.no/oauth/authorization?client_id=857348bd-71b3-443f-be5d-f7bd4421668f" \
-                  "&response_type=code"
+            url = DATAPORTEN_URL
 
         return redirect(to=url)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ djangorestframework==3.9.1
 psycopg2-binary==2.7.7
 requests
 dataporten-auth
-python-social-auth==0.2.19
 django-cors-headers

--- a/uninett_api/settings/base.py
+++ b/uninett_api/settings/base.py
@@ -133,10 +133,6 @@ SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
-# Dataporten
-SOCIAL_AUTH_DATAPORTEN_FEIDE_SSL_PROTOCOL = True
-
 # CORS
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
-# CORS_URLS_REGEX = r'^/connect/.*$'


### PR DESCRIPTION
It is necessary to set different Dataporten URLs for different servers,
because different Dataporten applications (development, testing and
production) have different authentication URLs.

- Localize Dataporten URL to _secrets
- Remove social-auth