### PR TITLE
Fix ISO format

### DIFF
--- a/connect/classes/adapter.py
+++ b/connect/classes/adapter.py
@@ -71,7 +71,7 @@ class HiveManagerAdapter(AdHocAdapter):
     def _get_generation_data(feide_username: str, group_id: int, full_name: str, organization_name: str, policy: str,
                              device_type: str, deliver_by_email: bool, email: str):
         feide_username = feide_username.strip('feide:').split('@')[0]
-        hive_manager_user_name = f"{feide_username}: {datetime.datetime.now().replace(microsecond=0).isoformat('')}"
+        hive_user_name = f"{feide_username}: {datetime.datetime.now().replace(microsecond=0).strftime('%y%m%d%H%M%S')}"
 
         return {
             "deliverMethod": "NO_DELIVERY" if not deliver_by_email else "EMAIL",
@@ -81,6 +81,6 @@ class HiveManagerAdapter(AdHocAdapter):
             "email": email,
             "organization": organization_name,
             "policy": policy,
-            "userName": hive_manager_user_name,
+            "userName": hive_user_name,
             "purpose": device_type
         }


### PR DESCRIPTION
We in fact do not want the ISO format, and the datetime.isoformat
function does not allow an empty string as a separator. Use strftime
instead.