### PR TITLE
Hotfix: Attempt json.loads everywhere

### DIFF
--- a/connect/classes/authenticator.py
+++ b/connect/classes/authenticator.py
@@ -3,17 +3,14 @@ import json
 from django.contrib.sessions.models import Session
 from rest_framework.exceptions import ValidationError
 
-from connect.utils import get_user_data
+from connect.utils import get_user_data, attempt_json_loads
 from iotconnect.classes import Authenticator
 
 
 class FeideAuthenticator(Authenticator):
     def validate_data(self, data, **kwargs):
         # Convert to JSON
-        try:
-            data = json.loads(data)
-        except TypeError:
-            pass
+        data = attempt_json_loads(data)
 
         if self.request.method.upper() != 'GET' and not data.get('session_key', None):
             # session_key is required when posting, because sessions will not work when posting using XmlHttpRequests.

--- a/connect/models.py
+++ b/connect/models.py
@@ -4,6 +4,7 @@ import requests
 from django.db import models
 from model_utils import FieldTracker
 
+from connect.utils import attempt_json_loads
 from uninett_api.settings._secrets import OWNER_ID, HEADERS
 
 
@@ -82,7 +83,8 @@ class DeviceRegistration(models.Model):
     def delete_from_hive_manager(self):
         url = "https://cloud-ie.aerohive.com/xapi/v1/identity/credentials"
         get_params = {'ownerId': OWNER_ID, 'ids': [], 'userName': self.hive_manager_id}
-        hive_manager_user = json.loads(requests.get(url=url, params=get_params, headers=HEADERS)._content)['data'][0]
+        hive_manager_user = attempt_json_loads(requests.get(url=url, params=get_params,
+                                                            headers=HEADERS)._content)['data'][0]
         real_id = hive_manager_user['id']
 
         post_params = {'ownerId': OWNER_ID, 'ids': [real_id]}

--- a/connect/utils.py
+++ b/connect/utils.py
@@ -15,7 +15,7 @@ def get_access_token(code):
                'redirect_uri': f"{BACKEND_URL}/connect/complete/dataporten/"}
 
     response = requests.post(url=url, data=payload, headers=DATAPORTEN_HEADERS)
-    access_token = json.loads(response.content)['access_token']
+    access_token = attempt_json_loads(response.content)['access_token']
 
     return access_token
 
@@ -25,10 +25,17 @@ def get_user_data(access_token):
     headers = {'Authorization': f'Bearer {access_token}'}
 
     response = requests.get(url=url, headers=headers)
-    content = json.loads(response.content)
+    content = attempt_json_loads(response.content)
     return content.get('user', None)
 
 
 def get_first_name(user_data):
     name = user_data.get('name', 'bruker')
     return name.split(' ')[0]
+
+
+def attempt_json_loads(data):
+    try:
+        return json.loads(data)
+    except TypeError:
+        return data


### PR DESCRIPTION
We apparently cannot expect the content type to be the same across
environments. Could be a Caddy issue. Therefore, use an
attempt_json_loads function instead of json.loads.